### PR TITLE
Fix misdirected redirect and path typo

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2141,7 +2141,7 @@
     },
     {
       "source": "/portkey-endpoints/analytics/graphs-time-series-data",
-      "destination": "http://localhost:3000/api-reference/admin-api/control-plane/analytics/graphs-time-series-data/get-cache-hit-latency-data"
+      "destination": "/api-reference/admin-api/control-plane/analytics/graphs-time-series-data/get-cache-hit-latency-data"
     },
     {
       "source": "/api-reference/virtual-keys",
@@ -2156,7 +2156,7 @@
       "destination": "/api-reference/admin-api/data-plane/logs/insert-a-log"
     },
     {
-      "source": "/integrations/llms/openai/structued-outputs",
+      "source": "/integrations/llms/openai/structured-outputs",
       "destination": "/integrations/llms/openai/structured-outputs"
     },
     {


### PR DESCRIPTION
## Summary
- fix redirect pointing to localhost
- fix typo in redirect path

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f46054b708333b3958d16b46373fa