### PR TITLE
Fix invalid localhost links

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2186,7 +2186,7 @@
     },
     {
       "source": "/portkey-endpoints/analytics/graphs-time-series-data",
-      "destination": "http://localhost:3000/api-reference/admin-api/control-plane/analytics/graphs-time-series-data/get-cache-hit-latency-data"
+      "destination": "/api-reference/admin-api/control-plane/analytics/graphs-time-series-data/get-cache-hit-latency-data"
     },
     {
       "source": "/api-reference/virtual-keys",

--- a/integrations/llms/openai3.mdx
+++ b/integrations/llms/openai3.mdx
@@ -325,7 +325,7 @@ main();
 **On-Prem Deployment (AWS, GCP, Azure)**
 Portkey's data & control planes can be fully deployed on-prem with the Enterprise license.
 
-<Card horizontal icon="lightbulb" title="More details here →" href="http://localhost:3000/product/enterprise-offering/private-cloud-deployments" />
+<Card horizontal icon="lightbulb" title="More details here →" href="/product/enterprise-offering/private-cloud-deployments" />
 
 ---
 

--- a/integrations/llms/x-ai.mdx
+++ b/integrations/llms/x-ai.mdx
@@ -233,7 +233,7 @@ main();
 <Accordion title="On-Prem Deployment (AWS, GCP, Azure)">
     Portkey's data & control planes can be fully deployed on-prem with the Enterprise license.
 
-    [More details here](http://localhost:3000/product/enterprise-offering/private-cloud-deployments)
+    [More details here](/product/enterprise-offering/private-cloud-deployments)
 </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
## Summary
- fix stray localhost redirect in `docs.json`
- update x-ai integration docs
- update openai3 integration docs

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f467bb910833397ec187897299aa4