### PR TITLE
Fix typos in rate limiting guide

### DIFF
--- a/guides/getting-started/tackling-rate-limiting.mdx
+++ b/guides/getting-started/tackling-rate-limiting.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Tackling Rate Limiting"
-description: "LLMs are **costly** to run. As their usage increaases, the providers have to balance serving user requests v/s straining their GPU resources too thin. They generally deal with this by putting _rate limits_ on how many requests a user can send in a minute or in a day."
+description: "LLMs are **costly** to run. As their usage increases, the providers have to balance serving user requests v/s straining their GPU resources too thin. They generally deal with this by putting _rate limits_ on how many requests a user can send in a minute or in a day."
 ---
 
 For example, for the text-to-speech model `tts-1-hd` from OpenAI, you can not send **more than 7** requests in minute. Any extra request automatically fails.
 
-There are many real-world use cases where it's possilbe to run into rate limits:
+There are many real-world use cases where it's possible to run into rate limits:
 
 * When your requests have very high input-tokens count or a very long context, you can hit token thresholds
 * When you are running a complex and long prompts pipeline that fires hundreds of requests at once, you can hit both token & request limits


### PR DESCRIPTION
## Summary
- fix typo in front matter description in tackling rate limiting guide
- fix typo in introductory paragraph listing real-world scenarios

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f47b5f88c8333bb55cc0fdd139b2b