### PR TITLE
Add OpenAPI validation workflow

### DIFF
--- a/.github/workflows/openapi-validate.yml
+++ b/.github/workflows/openapi-validate.yml
@@ -1,0 +1,19 @@
+name: Validate OpenAPI specification
+
+on:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install openapi-spec-validator
+        run: |
+          python -m pip install --upgrade pip
+          pip install openapi-spec-validator
+      - name: Validate OpenAPI document
+        run: openapi-spec-validator openapi.yaml


### PR DESCRIPTION
## Summary
- add workflow to validate `openapi.yaml`

## Testing
- `npm run test` *(fails: Missing script)*
- `openapi-spec-validator openapi.yaml` *(fails: Validation Error)*

------
https://chatgpt.com/codex/tasks/task_e_683f47bee0cc8333b86a2863f68a0862