### PR TITLE
Fix typo in common errors page

### DIFF
--- a/support/common-errors-and-resolutions.mdx
+++ b/support/common-errors-and-resolutions.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Common Errors & Resolutions"
-description: Since Portkey functions as a gateway - you may encounter Portkey-related, as well as non-Portkey related erros while using our services.
+description: Since Portkey functions as a gateway - you may encounter Portkey-related, as well as non-Portkey related errors while using our services.
 ---
 
 


### PR DESCRIPTION
## Summary
- fix typo in front matter of support/common-errors-and-resolutions.mdx

## Testing
- `npm test` *(fails: missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_683f47be3f7483339d29301feabdbbc5