### PR TITLE
Fix submit tool outputs endpoint name

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6452,7 +6452,7 @@ paths:
 
   /threads/{thread_id}/runs/{run_id}/submit_tool_outputs:
     post:
-      operationId: submitToolOuputsToRun
+      operationId: submitToolOutputsToRun
       tags:
         - Assistants
       summary: |
@@ -25168,7 +25168,7 @@ x-code-samples:
           key: modifyRun
           path: modifyRun
         - type: endpoint
-          key: submitToolOuputsToRun
+          key: submitToolOutputsToRun
           path: submitToolOutputs
         - type: endpoint
           key: cancelRun


### PR DESCRIPTION
## Summary
- fix typo in the `submit_tool_outputs` endpoint operationId
- update navigation key for the endpoint

## Testing
- `grep -n submitToolOutputsToRun -n openapi.yaml`

------
https://chatgpt.com/codex/tasks/task_e_683f47bbedac8333bcfc21cf2d414742