### PR TITLE
fix grammar in FunctionParameters description

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17535,7 +17535,7 @@ components:
 
     FunctionParameters:
       type: object
-      description: "The parameters the functions accepts, described as a JSON Schema object. See the [guide](https://platform.openai.com/docs/guides/function-calling) for examples, and the [JSON Schema reference](https://json-schema.org/understanding-json-schema/) for documentation about the format. \n\nOmitting `parameters` defines a function with an empty parameter list."
+      description: "The parameters the function accepts, described as a JSON Schema object. See the [guide](https://platform.openai.com/docs/guides/function-calling) for examples, and the [JSON Schema reference](https://json-schema.org/understanding-json-schema/) for documentation about the format. \n\nOmitting `parameters` defines a function with an empty parameter list."
       additionalProperties: true
 
     ChatCompletionFunctions:


### PR DESCRIPTION
## Summary
- fix grammar in FunctionParameters description

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f48b23c288333921aeb9d449b59f8