### PR TITLE
Fix truncation description typo

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -20220,7 +20220,7 @@ components:
     TruncationObject:
       type: object
       title: Thread Truncation Controls
-      description: Controls for how a thread will be truncated prior to the run. Use this to control the intial context window of the run.
+      description: Controls for how a thread will be truncated prior to the run. Use this to control the initial context window of the run.
       properties:
         type:
           type: string


### PR DESCRIPTION
## Summary
- correct typo in `openapi.yaml` describing `TruncationObject`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f48aad0588333811aa52ef08482ad